### PR TITLE
Fix end comment for explicit encryption find

### DIFF
--- a/queryable-encryption/node/exp/reader/insert_encrypted_document.js
+++ b/queryable-encryption/node/exp/reader/insert_encrypted_document.js
@@ -92,8 +92,8 @@ async function run() {
     });
 
     console.log("Finding a document with manually encrypted field:");
-    // end-find
     console.log(await encryptedColl.findOne({ patientId: findPayload }));
+    // end-find
   } finally {
     await unencryptedClient.close();
     await encryptedClient.close();


### PR DESCRIPTION
Fixing an "end-find" literalinclude comment that was in the incorrect spot in the code